### PR TITLE
Fixing destination filenames.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <packaging>jar</packaging>
     <groupId>org.webjars</groupId>
     <artifactId>Eonasdan-bootstrap-datetimepicker</artifactId>
-    <version>3.1.4-SNAPSHOT</version>
+    <version>3.1.3-1-SNAPSHOT</version>
     <name>Eonasdan-bootstrap-datetimepicker</name>
     <description>WebJar for Eonasdan-bootstrap-datetimepicker</description>
     <url>http://webjars.org</url>
@@ -77,9 +77,9 @@
                         <configuration>
                             <target>
                                 <mkdir dir="${destDir}" />
-                                <get src="${upstream.url}/css/bootstrap-datetimepicker.css" dest="${destDir}/css" />
-                                <get src="${upstream.url}/css/bootstrap-datetimepicker.min.css" dest="${destDir}/css" />
-                                <get src="${upstream.url}/js/bootstrap-datetimepicker.min.js" dest="${destDir}/js" />
+                                <get src="${upstream.url}/css/bootstrap-datetimepicker.css" dest="${destDir}/bootstrap-datetimepicker.css" />
+                                <get src="${upstream.url}/css/bootstrap-datetimepicker.min.css" dest="${destDir}/bootstrap-datetimepicker.min.css" />
+                                <get src="${upstream.url}/js/bootstrap-datetimepicker.min.js" dest="${destDir}/bootstrap-datetimepicker.min.js" />
                             </target>
                         </configuration>
                     </execution>


### PR DESCRIPTION
There used to be only 2 files in the webjar - `META-INF/resources/webjars/Eonasdan-bootstrap-datetimepicker/3.1.3/css` and `META-INF/resources/webjars/Eonasdan-bootstrap-datetimepicker/3.1.3/js`. This was hiding the non-minified file. Also, because the filenames didn't end with `.js` or `.css`, the contents were returned as `application/octet-stream` instead of `application/javascript`/`text/css`.
