### PR TITLE
bootstrap-datetimepicker.js not included

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,15 +11,15 @@
     <packaging>jar</packaging>
     <groupId>org.webjars</groupId>
     <artifactId>Eonasdan-bootstrap-datetimepicker</artifactId>
-    <version>4.14.31-SNAPSHOT</version>
+    <version>4.15.35</version>
     <name>Eonasdan-bootstrap-datetimepicker</name>
     <description>WebJar for Eonasdan-bootstrap-datetimepicker</description>
     <url>http://webjars.org</url>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <upstream.version>v4.14.30</upstream.version>
-        <upstream.url>https://raw.githubusercontent.com/Eonasdan/bootstrap-datetimepicker/${upstream.version}/build</upstream.url>
+        <upstream.version>4.15.35</upstream.version>
+        <upstream.url>https://raw.githubusercontent.com/Eonasdan/bootstrap-datetimepicker/${upstream.version}</upstream.url>
         <destDir>${project.build.outputDirectory}/META-INF/resources/webjars/${project.artifactId}/${project.version}</destDir>
         <requirejs>
             {
@@ -82,9 +82,10 @@
                         <configuration>
                             <target>
                                 <mkdir dir="${destDir}" />
-                                <get src="${upstream.url}/css/bootstrap-datetimepicker.css" dest="${destDir}/bootstrap-datetimepicker.css" />
-                                <get src="${upstream.url}/css/bootstrap-datetimepicker.min.css" dest="${destDir}/bootstrap-datetimepicker.min.css" />
-                                <get src="${upstream.url}/js/bootstrap-datetimepicker.min.js" dest="${destDir}/bootstrap-datetimepicker.min.js" />
+                                <get src="${upstream.url}/build/css/bootstrap-datetimepicker.css" dest="${destDir}/bootstrap-datetimepicker.css" />
+                                <get src="${upstream.url}/build/css/bootstrap-datetimepicker.min.css" dest="${destDir}/bootstrap-datetimepicker.min.css" />
+                                <get src="${upstream.url}/build/js/bootstrap-datetimepicker.min.js" dest="${destDir}/bootstrap-datetimepicker.min.js" />
+                                <get src="${upstream.url}/src/js/bootstrap-datetimepicker.js" dest="${destDir}/bootstrap-datetimepicker.min.js" />
                             </target>
                         </configuration>
                     </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <upstream.version>4.15.35</upstream.version>
+        <upstream.version>4.15.35-SNAPSHOT</upstream.version>
         <upstream.url>https://raw.githubusercontent.com/Eonasdan/bootstrap-datetimepicker/${upstream.version}</upstream.url>
         <destDir>${project.build.outputDirectory}/META-INF/resources/webjars/${project.artifactId}/${project.version}</destDir>
         <requirejs>
@@ -82,10 +82,10 @@
                         <configuration>
                             <target>
                                 <mkdir dir="${destDir}" />
-                                <get src="${upstream.url}/build/css/bootstrap-datetimepicker.css" dest="${destDir}/bootstrap-datetimepicker.css" />
-                                <get src="${upstream.url}/build/css/bootstrap-datetimepicker.min.css" dest="${destDir}/bootstrap-datetimepicker.min.css" />
-                                <get src="${upstream.url}/build/js/bootstrap-datetimepicker.min.js" dest="${destDir}/bootstrap-datetimepicker.min.js" />
-                                <get src="${upstream.url}/src/js/bootstrap-datetimepicker.js" dest="${destDir}/bootstrap-datetimepicker.min.js" />
+                                <get src="${upstream.url}/build/css/bootstrap-datetimepicker.css" dest="${destDir}/css/bootstrap-datetimepicker.css" />
+                                <get src="${upstream.url}/build/css/bootstrap-datetimepicker.min.css" dest="${destDir}/css/bootstrap-datetimepicker.min.css" />
+                                <get src="${upstream.url}/build/js/bootstrap-datetimepicker.min.js" dest="${destDir}/js/bootstrap-datetimepicker.min.js" />
+                                <get src="${upstream.url}/src/js/bootstrap-datetimepicker.js" dest="${destDir}/js/bootstrap-datetimepicker.js" />
                             </target>
                         </configuration>
                     </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -11,14 +11,14 @@
     <packaging>jar</packaging>
     <groupId>org.webjars</groupId>
     <artifactId>Eonasdan-bootstrap-datetimepicker</artifactId>
-    <version>4.15.35</version>
+    <version>4.15.35-SNAPSHOT</version>
     <name>Eonasdan-bootstrap-datetimepicker</name>
     <description>WebJar for Eonasdan-bootstrap-datetimepicker</description>
     <url>http://webjars.org</url>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <upstream.version>4.15.35-SNAPSHOT</upstream.version>
+        <upstream.version>4.15.35</upstream.version>
         <upstream.url>https://raw.githubusercontent.com/Eonasdan/bootstrap-datetimepicker/${upstream.version}</upstream.url>
         <destDir>${project.build.outputDirectory}/META-INF/resources/webjars/${project.artifactId}/${project.version}</destDir>
         <requirejs>


### PR DESCRIPTION
**bootstrap-datetimepicker.js** is at *src/js* in **Eonasdan** repo (not in *build* directory).

I think **upstream.url** should be updated from *https://raw.githubusercontent.com/Eonasdan/bootstrap-datetimepicker/${upstream.version}/build* to *https://raw.githubusercontent.com/Eonasdan/bootstrap-datetimepicker/${upstream.version}*, and update **antrun** task to include **bootstrap-datetimepicker.js** and adapt current file paths.

Also updated version (v4.14.30) to latest available (4.15.35)